### PR TITLE
FF_PROFILE_AAC_* (removed in FFmpeg 8) -> AV_PROFILE_AAC_*

### DIFF
--- a/plugins/ffmpeg/codecs.c
+++ b/plugins/ffmpeg/codecs.c
@@ -1127,10 +1127,10 @@ static const enum_t mb_decision[] =
 
 static const enum_t faac_profile[] =
   {
-    { "main", FF_PROFILE_AAC_MAIN },
-    { "lc",   FF_PROFILE_AAC_LOW  },
-    { "ssr",  FF_PROFILE_AAC_SSR  },
-    { "ltp",  FF_PROFILE_AAC_LTP  }
+    { "main", AV_PROFILE_AAC_MAIN },
+    { "lc",   AV_PROFILE_AAC_LOW  },
+    { "ssr",  AV_PROFILE_AAC_SSR  },
+    { "ltp",  AV_PROFILE_AAC_LTP  }
   };
 
 #define PARAM_ENUM(n, var, arr) \


### PR DESCRIPTION
Removed in https://github.com/FFmpeg/FFmpeg/commit/822432769868da325ba03774df1084aa78b9a5a0